### PR TITLE
updates dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@octokit/rest": "^18.5.2",
-        "ghost-inspector": "^5.0.1"
+        "@octokit/rest": "^18.5.3",
+        "ghost-inspector": "^5.0.2"
       },
       "devDependencies": {
-        "eslint": "^7.24.0",
-        "eslint-config-prettier": "^8.2.0",
+        "eslint": "^7.25.0",
+        "eslint-config-prettier": "^8.3.0",
         "eslint-config-standard": "^16.0.2",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-node": "^11.1.0",
@@ -23,6 +23,9 @@
         "prettier": "^2.2.1",
         "proxyquire": "^2.1.3",
         "sinon": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=8.9.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -200,9 +203,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.0.0.tgz",
-      "integrity": "sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.1.1.tgz",
+      "integrity": "sha512-ICBhnEb+ahi/TTdNuYb/kTyKVBgAM0VD4k6JPzlhJyzt3Z+Tq/bynwCD+gpkJP7AEcNnzC8YO5R39trmzEo2UA=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "2.13.3",
@@ -224,11 +227,11 @@
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz",
-      "integrity": "sha512-Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.1.tgz",
+      "integrity": "sha512-vvWbPtPqLyIzJ7A4IPdTl+8IeuKAwMJ4LjvmqWOOdfSuqWQYZXq2CEd0hsnkidff2YfKlguzujHs/reBdAx8Sg==",
       "dependencies": {
-        "@octokit/types": "^6.13.0",
+        "@octokit/types": "^6.13.1",
         "deprecation": "^2.3.1"
       },
       "peerDependencies": {
@@ -259,22 +262,22 @@
       }
     },
     "node_modules/@octokit/rest": {
-      "version": "18.5.2",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.2.tgz",
-      "integrity": "sha512-Kz03XYfKS0yYdi61BkL9/aJ0pP2A/WK5vF/syhu9/kY30J8He3P68hv9GRpn8bULFx2K0A9MEErn4v3QEdbZcw==",
+      "version": "18.5.3",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.3.tgz",
+      "integrity": "sha512-KPAsUCr1DOdLVbZJgGNuE/QVLWEaVBpFQwDAz/2Cnya6uW2wJ/P5RVGk0itx7yyN1aGa8uXm2pri4umEqG1JBA==",
       "dependencies": {
         "@octokit/core": "^3.2.3",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.0.0"
+        "@octokit/plugin-rest-endpoint-methods": "5.0.1"
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
-      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.2.tgz",
+      "integrity": "sha512-jN5LImYHvv7W6SZargq1UMJ3EiaqIz5qkpfsv4GAb4b16SGqctxtOU2TQAZxvsKHkOw2A4zxdsi5wR9en1/ezQ==",
       "dependencies": {
-        "@octokit/openapi-types": "^6.0.0"
+        "@octokit/openapi-types": "^6.1.1"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -886,9 +889,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.24.0.tgz",
-      "integrity": "sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
+      "integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
@@ -940,9 +943,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.2.0.tgz",
-      "integrity": "sha512-dWV9EVeSo2qodOPi1iBYU/x6F6diHv8uujxbxr77xExs3zTAlNXvVZKiyLsQGNz7yPV2K49JY5WjPzNIuDc2Bw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -1483,9 +1486,9 @@
       }
     },
     "node_modules/ghost-inspector": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ghost-inspector/-/ghost-inspector-5.0.1.tgz",
-      "integrity": "sha512-7Tfk8bxY7fJzxn8LLblO8WEKqgb8aB3KIhng/rZ4liK4yibHvedjcXvKTrR6LI+yjhsDq2l3QFDKEl6C5RDbkg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ghost-inspector/-/ghost-inspector-5.0.2.tgz",
+      "integrity": "sha512-6Lys8N1fbaGLzRuetx4FN+YQgJWJM5IvogEvwkiXWHpAsA6EAjCOABbTvk80UpFIeXP5H5+NqP2XAl+LzfDeuA==",
       "dependencies": {
         "chalk": "^4.1.0",
         "request": "^2.88.2",
@@ -3687,9 +3690,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.0.0.tgz",
-      "integrity": "sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.1.1.tgz",
+      "integrity": "sha512-ICBhnEb+ahi/TTdNuYb/kTyKVBgAM0VD4k6JPzlhJyzt3Z+Tq/bynwCD+gpkJP7AEcNnzC8YO5R39trmzEo2UA=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "2.13.3",
@@ -3706,11 +3709,11 @@
       "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz",
-      "integrity": "sha512-Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.1.tgz",
+      "integrity": "sha512-vvWbPtPqLyIzJ7A4IPdTl+8IeuKAwMJ4LjvmqWOOdfSuqWQYZXq2CEd0hsnkidff2YfKlguzujHs/reBdAx8Sg==",
       "requires": {
-        "@octokit/types": "^6.13.0",
+        "@octokit/types": "^6.13.1",
         "deprecation": "^2.3.1"
       }
     },
@@ -3738,22 +3741,22 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.5.2",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.2.tgz",
-      "integrity": "sha512-Kz03XYfKS0yYdi61BkL9/aJ0pP2A/WK5vF/syhu9/kY30J8He3P68hv9GRpn8bULFx2K0A9MEErn4v3QEdbZcw==",
+      "version": "18.5.3",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.3.tgz",
+      "integrity": "sha512-KPAsUCr1DOdLVbZJgGNuE/QVLWEaVBpFQwDAz/2Cnya6uW2wJ/P5RVGk0itx7yyN1aGa8uXm2pri4umEqG1JBA==",
       "requires": {
         "@octokit/core": "^3.2.3",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.0.0"
+        "@octokit/plugin-rest-endpoint-methods": "5.0.1"
       }
     },
     "@octokit/types": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
-      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.2.tgz",
+      "integrity": "sha512-jN5LImYHvv7W6SZargq1UMJ3EiaqIz5qkpfsv4GAb4b16SGqctxtOU2TQAZxvsKHkOw2A4zxdsi5wR9en1/ezQ==",
       "requires": {
-        "@octokit/openapi-types": "^6.0.0"
+        "@octokit/openapi-types": "^6.1.1"
       }
     },
     "@sinonjs/commons": {
@@ -4226,9 +4229,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.24.0.tgz",
-      "integrity": "sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
+      "integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -4271,9 +4274,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.2.0.tgz",
-      "integrity": "sha512-dWV9EVeSo2qodOPi1iBYU/x6F6diHv8uujxbxr77xExs3zTAlNXvVZKiyLsQGNz7yPV2K49JY5WjPzNIuDc2Bw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
       "dev": true,
       "requires": {}
     },
@@ -4684,9 +4687,9 @@
       }
     },
     "ghost-inspector": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ghost-inspector/-/ghost-inspector-5.0.1.tgz",
-      "integrity": "sha512-7Tfk8bxY7fJzxn8LLblO8WEKqgb8aB3KIhng/rZ4liK4yibHvedjcXvKTrR6LI+yjhsDq2l3QFDKEl6C5RDbkg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ghost-inspector/-/ghost-inspector-5.0.2.tgz",
+      "integrity": "sha512-6Lys8N1fbaGLzRuetx4FN+YQgJWJM5IvogEvwkiXWHpAsA6EAjCOABbTvk80UpFIeXP5H5+NqP2XAl+LzfDeuA==",
       "requires": {
         "chalk": "^4.1.0",
         "request": "^2.88.2",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@octokit/rest": "^18.5.2",
-    "ghost-inspector": "^5.0.1"
+    "@octokit/rest": "^18.5.3",
+    "ghost-inspector": "^5.0.2"
   },
   "repository": {
     "type": "git",
@@ -40,8 +40,8 @@
   },
   "homepage": "https://github.com/ghost-inspector/netlify-plugin#readme",
   "devDependencies": {
-    "eslint": "^7.24.0",
-    "eslint-config-prettier": "^8.2.0",
+    "eslint": "^7.25.0",
+    "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
The only dependency that couldn't be updated to the latest was `eslint-plugin-promise@5.1.0` because `eslint-config-standard` still has a peer set at 4.2.1. I suppose we'll have to wait for an update to that or force it. Doesn't seem necessary to force yet.

```bash
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! Found: eslint-plugin-promise@5.1.0
npm ERR! node_modules/eslint-plugin-promise
npm ERR!   dev eslint-plugin-promise@"^5.1.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer eslint-plugin-promise@"^4.2.1" from eslint-config-standard@16.0.2
npm ERR! node_modules/eslint-config-standard
npm ERR!   dev eslint-config-standard@"^16.0.2" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/jordankohl/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jordankohl/.npm/_logs/2021-04-27T17_44_24_583Z-debug.log
```