### PR TITLE
improves error handling

### DIFF
--- a/github.js
+++ b/github.js
@@ -20,8 +20,8 @@ module.exports = {
     // eslint-disable-next-line camelcase
     target_url,
   }) => {
-    const octokit = new Octokit({ auth })
     try {
+      const octokit = new Octokit({ auth })
       const [owner, repoWithGit] = process.env.REPOSITORY_URL.split(
         "github.com/"
       )[1].split("/")
@@ -36,7 +36,7 @@ module.exports = {
         target_url,
       })
     } catch (error) {
-      throw Error(error)
+      console.log(error)
     }
   }
 }


### PR DESCRIPTION
Instead of top-level try/catch, this change wraps the Ghost Inspector request in its own block that will fail the plugin if it encounters an error. The GitHub blocks were already wrapped in a try/catch, but instead of throwing an error they will only log the error since the GitHub integration is optional anyway.

fixes #5, fixes #6